### PR TITLE
Fix incorrect documentation of offset loss unit for Open/Short/Load Standards

### DIFF
--- a/SignalIntegrity/Lib/Measurement/CalKit/Standards/LoadStandard.py
+++ b/SignalIntegrity/Lib/Measurement/CalKit/Standards/LoadStandard.py
@@ -32,7 +32,7 @@ class LoadStandard(SParameters):
         @param f list of frequencies
         @param offsetDelay (optional) float electrical length of offset in s (defaults to 0 s)
         @param offsetZ0 (optional) float real characteristic impedance of offset (defaults to 50 ohms)
-        @param offsetLoss (optional) float loss due to skin-effect defined in Gohms/s at f0 (defaults to 0).
+        @param offsetLoss (optional) float loss due to skin-effect defined in ohms/s at f0 (defaults to 0).
         @param f0 (optional) float frequency where the offset loss is defined (defaults to 1e9).
         @param terminationZ (optional) float real impedance of termination.
         The result is that the class becomes the base-class SParameters with the s-parameters

--- a/SignalIntegrity/Lib/Measurement/CalKit/Standards/OpenStandard.py
+++ b/SignalIntegrity/Lib/Measurement/CalKit/Standards/OpenStandard.py
@@ -32,7 +32,7 @@ class OpenStandard(SParameters):
         @param f list of frequencies
         @param offsetDelay (optional) float electrical length of offset in s (defaults to 0 s)
         @param offsetZ0 (optional) float real characteristic impedance of offset (defaults to 50 ohms)
-        @param offsetLoss (optional) float loss due to skin-effect defined in Gohms/s at 1 GHz (defaults to 0).
+        @param offsetLoss (optional) float loss due to skin-effect defined in ohms/s at 1 GHz (defaults to 0).
         @param f0 (optional) float frequency where the offset loss is defined (defaults to 1e9).
         @param C0 (optional) float polynomial coefficient for capacitance of open termination
         @param C1 (optional) float polynomial coefficient for capacitance of open termination

--- a/SignalIntegrity/Lib/Measurement/CalKit/Standards/ShortStandard.py
+++ b/SignalIntegrity/Lib/Measurement/CalKit/Standards/ShortStandard.py
@@ -32,7 +32,7 @@ class ShortStandard(SParameters):
         @param f list of frequencies
         @param offsetDelay (optional) float electrical length of offset in s (defaults to 0 s)
         @param offsetZ0 (optional) float real characteristic impedance of offset (defaults to 50 ohms)
-        @param offsetLoss (optional) float loss due to skin-effect defined in Gohms/s at 1 GHz (defaults to 0).
+        @param offsetLoss (optional) float loss due to skin-effect defined in ohms/s at 1 GHz (defaults to 0).
         @param f0 (optional) float frequency where the offset loss is defined (defaults to 1e9).
         @param L0 (optional) float polynomial coefficient for inductance of short termination
         @param L1 (optional) float polynomial coefficient for inductance of short termination


### PR DESCRIPTION
The documentation of `offsetLoss` in `OpenStandard`, `ShortStandard` and `LoadStandard` appears incorrect. It reads:

> offsetLoss (optional) float loss due to skin-effect defined in **Gohms/s** at f0 (defaults to 0).

However, all of these classes actually pass the `offsetLoss` unchanged into the `Offset` class.

    class OpenStandard(SParameters):
        """class providing the s-parameters of an open standard as commonly defined
        for a calibration kit."""
        def __init__(self,f,offsetDelay=0.0,offsetZ0=50.0,offsetLoss=0.0,f0=1e9,
                     C0=0.0,C1=0.0,C2=0.0,C3=0.0):
            # [...]
            offsetSParameters=Offset(f,offsetDelay,offsetZ0,offsetLoss,f0)

And the `Offset` class actually interprets `offsetLoss` in **ohms/s**, not **Gohms/s**.

> offsetLoss (optional) float loss due to skin-effect defined in **ohms/s** at f0 (defaults to 0).

Due to this typo, I've wasted hours trying to solve my incorrect calculations in SignalIntegrity, it was because `offsetLoss` didn't do anything - it was too small by 9 orders of magnitude.

This patch fixes the documentation. 